### PR TITLE
Support disabling drift detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,21 @@
 `tf-controller` is an experimental controller for Flux to reconcile Terraform resources.
 
 ## Features
-  
-  * **Fully GitOps Automation for Terraform**: With setting `.spec.approvePlan=true`, it allows a `Terraform` object 
-   to be reconciled and act as the representation of your Terraform resources. The TF-controller uses the spec of 
-   the `Terraform` object to perform `plan`, `apply` its associated Terraform resources. It then stores 
-   the `TFSTATE` of the applied resources as a `Secret` inside the Kubernetes cluster. After `.spec.interval` passes, 
-   the controller performs drift detection to check if there is a drift occurred between your live system, 
-   and your Terraform resources. If a drift occurs, the plan to fix that drift will be generated and applied automatically. 
+
+  * **Fully GitOps Automation for Terraform**: With setting `.spec.approvePlan=true`, it allows a `Terraform` object
+   to be reconciled and act as the representation of your Terraform resources. The TF-controller uses the spec of
+   the `Terraform` object to perform `plan`, `apply` its associated Terraform resources. It then stores
+   the `TFSTATE` of the applied resources as a `Secret` inside the Kubernetes cluster. After `.spec.interval` passes,
+   the controller performs drift detection to check if there is a drift occurred between your live system,
+   and your Terraform resources. If a drift occurs, the plan to fix that drift will be generated and applied automatically.
    _This feature is available since v0.3.0._
   * **Drift detection**: This feature is a part of the GitOps automation feature. The controller detects and fixes drift
    for your infrastructures, based on the Terraform resources and their `TFSTATE`. _This feature is available since v0.5.0._
-  * **Plan and Manual Approve**: This feature allows you to separate the `plan`, out of the `apply` step, just like 
-   the Terraform workflow you are familiar with. A good thing about this is that it is done in a GitOps way. When a plan 
-   is generated, the controller shows you a message like **'set approvePlan: "plan-main-123" to apply this plan.'**. 
+  * **Plan and Manual Approve**: This feature allows you to separate the `plan`, out of the `apply` step, just like
+   the Terraform workflow you are familiar with. A good thing about this is that it is done in a GitOps way. When a plan
+   is generated, the controller shows you a message like **'set approvePlan: "plan-main-123" to apply this plan.'**.
    You make change to the field `.spec.approvePlan`, commit and push to tell the TF-controller to apply the plan for you.
-   With this GitOps workflow, you can optionally create and push this change to a new branch for your team member to 
+   With this GitOps workflow, you can optionally create and push this change to a new branch for your team member to
    review and approve too. _This feature is available since v0.6.0._
 
 ## Dependencies
@@ -83,7 +83,7 @@ metadata:
   namespace: flux-system
 spec:
 - approvePlan: "auto"
-+ approvePlan: "" # or you can omit this field 
++ approvePlan: "" # or you can omit this field
   path: ./
   sourceRef:
     kind: GitRepository
@@ -109,22 +109,43 @@ spec:
     namespace: flux-system
 ```
 
+### Disable Drift Detection
+
+Drift detection is enabled by default. Use the `.spec.disableDriftDetection` field to disable:
+
+```yaml
+apiVersion: infra.contrib.fluxcd.io/v1alpha1
+kind: Terraform
+metadata:
+  name: helloworld
+  namespace: flux-system
+spec:
+  approvePlan: "auto"
+  disableDriftDetection: true
+  path: ./
+  sourceRef:
+    kind: GitRepository
+    name: helloworld
+    namespace: flux-system
+```
+
+
 ## Examples
-  * A Terraform GitOps with Flux to automatic reconcile your [AWS IAM Policies](https://github.com/tf-controller/aws-iam-policies). 
+  * A Terraform GitOps with Flux to automatic reconcile your [AWS IAM Policies](https://github.com/tf-controller/aws-iam-policies).
 
 ## Roadmap
 
 ### Q1 2022
   * Terraform outputs as Kubernetes Secrets
-  * Secret and ConfigMap as input variables 
-  * Support the GitOps way to "plan" / "re-plan" 
+  * Secret and ConfigMap as input variables
+  * Support the GitOps way to "plan" / "re-plan"
   * Support the GitOps way to "apply"
   * Drift detection
   * Support auto-apply so that the reconciliation detect drifts and always make changes
   * Test coverage reaching 70%
 
-### Q2 2022  
-  * Interop with Notification controller's Events and Alert   
+### Q2 2022
+  * Interop with Notification controller's Events and Alert
   * Interop with Kustomization controller's health checks (via the Output resources)
   * Test coverage reaching 75%
 

--- a/api/v1alpha1/terraform_types.go
+++ b/api/v1alpha1/terraform_types.go
@@ -115,6 +115,12 @@ type TerraformSpec struct {
 	// +optional
 	WriteOutputsToSecret *WriteOutputsToSecretSpec `json:"writeOutputsToSecret,omitempty"`
 
+	// Disable automatic drift detection. Drift detection may be resource intensive in
+	// the context of a large cluster or complex Terraform statefile. Defaults to false.
+	// +kubebuilder:default:=false
+	// +optional
+	DisableDriftDetection bool `json:"disableDriftDetection,omitempty"`
+
 	// +optional
 	// PushSpec *PushSpec `json:"pushSpec,omitempty"`
 }

--- a/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
+++ b/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
@@ -72,6 +72,12 @@ spec:
                 description: Destroy produces a destroy plan. Applying the plan will
                   destroy all resources.
                 type: boolean
+              disableDriftDetection:
+                default: false
+                description: Disable automatic drift detection. Drift detection may
+                  be resource intensive in the context of a large cluster or complex
+                  Terraform statefile. Defaults to false.
+                type: boolean
               force:
                 default: false
                 description: Force instructs the controller to unconditionally re-plan

--- a/controllers/tc000200_disable_drift_detection_test.go
+++ b/controllers/tc000200_disable_drift_detection_test.go
@@ -1,0 +1,50 @@
+package controllers
+
+import (
+	"testing"
+
+	infrav1 "github.com/chanwit/tf-controller/api/v1alpha1"
+	. "github.com/onsi/gomega"
+)
+
+// +kubebuilder:docs-gen:collapse=Imports
+
+func Test_000200_disable_drift_detection(t *testing.T) {
+	Spec("This spec describes behaviour when drift detection is disabled")
+
+	g := NewWithT(t)
+
+	tf1 := infrav1.Terraform{
+		Spec: infrav1.TerraformSpec{
+			DisableDriftDetection: true,
+		},
+		Status: infrav1.TerraformStatus{
+			LastAttemptedRevision: "main/1234",
+			LastPlannedRevision:   "main/1234",
+			LastAppliedRevision:   "main/1234",
+			Plan: infrav1.PlanStatus{
+				Pending: "",
+			},
+		},
+	}
+
+	It("should not detect drift when true")
+	g.Expect(reconciler.shouldDetectDrift(tf1, "main/1234")).Should(BeFalse())
+
+	tf2 := infrav1.Terraform{
+		Spec: infrav1.TerraformSpec{
+			DisableDriftDetection: false,
+		},
+		Status: infrav1.TerraformStatus{
+			LastAttemptedRevision: "main/2345",
+			LastPlannedRevision:   "main/2345",
+			LastAppliedRevision:   "main/1234",
+			Plan: infrav1.PlanStatus{
+				Pending: "",
+			},
+		},
+	}
+
+	It("should detect drift when false")
+	g.Expect(reconciler.shouldDetectDrift(tf2, "main/2345")).Should(BeTrue())
+}

--- a/controllers/terraform_controller.go
+++ b/controllers/terraform_controller.go
@@ -30,10 +30,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sort"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	infrav1 "github.com/chanwit/tf-controller/api/v1alpha1"
 	securejoin "github.com/cyphar/filepath-securejoin"
@@ -204,6 +205,11 @@ func (r *TerraformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 func (r *TerraformReconciler) shouldDetectDrift(terraform infrav1.Terraform, revision string) bool {
+	// return false when drift detection is disabled
+	if terraform.Spec.DisableDriftDetection == true {
+		return false
+	}
+
 	// not support when Destroy == true
 	if terraform.Spec.Destroy == true {
 		return false


### PR DESCRIPTION
This change introduces a new field `.spec.disableDriftDetection` which when `true` will bypass drift detection. Defaults to false.

This may be desirable when working with a complex state file or large Kubernetes cluster.

Example usage, disabling drift detection:
```yaml
apiVersion: infra.contrib.fluxcd.io/v1alpha1
kind: Terraform
metadata:
  name: helloworld
  namespace: flux-system
spec:
  approvePlan: "auto"
  disableDriftDetection: true
  path: ./
  sourceRef:
    kind: GitRepository
    name: helloworld
    namespace: flux-system
```



Implements #14 

Signed-off-by: Piaras Hoban <piaras@weave.works>