### PR TITLE
Add gzip encoding annotation to tfplan secret and update tests

### DIFF
--- a/controllers/tc000010_no_outputs_test.go
+++ b/controllers/tc000010_no_outputs_test.go
@@ -150,12 +150,14 @@ func Test_000010_no_outputs_test(t *testing.T) {
 			return nil
 		}
 		return map[string]interface{}{
-			"SavedPlan":         tfplanSecret.Labels["savedPlan"],
-			"Is TFPlan empty ?": string(tfplanSecret.Data["tfplan"]) == "",
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"Is TFPlan empty ?":     string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":         "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
-		"Is TFPlan empty ?": false,
+		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"Is TFPlan empty ?":     false,
+		"HasEncodingAnnotation": true,
 	}))
 
 	It("should contain an Apply condition saying that the plan were apply successfully.")

--- a/controllers/tc000012_src_bucket_no_outputs_test.go
+++ b/controllers/tc000012_src_bucket_no_outputs_test.go
@@ -148,12 +148,14 @@ func Test_000012_src_bucket_no_outputs_test(t *testing.T) {
 			return nil
 		}
 		return map[string]interface{}{
-			"SavedPlan":         tfplanSecret.Labels["savedPlan"],
-			"Is TFPlan empty ?": string(tfplanSecret.Data["tfplan"]) == "",
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"Is TFPlan empty ?":     string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":         "plan-822c3dd335579b435b5ada924d6f38b227412a5c",
-		"Is TFPlan empty ?": false,
+		"SavedPlan":             "plan-822c3dd335579b435b5ada924d6f38b227412a5c",
+		"Is TFPlan empty ?":     false,
+		"HasEncodingAnnotation": true,
 	}))
 
 	It("should contain an Apply condition saying that the plan were apply successfully.")

--- a/controllers/tc000030_plan_only_no_outputs_test.go
+++ b/controllers/tc000030_plan_only_no_outputs_test.go
@@ -2,9 +2,10 @@ package controllers
 
 import (
 	"context"
-	corev1 "k8s.io/api/core/v1"
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/gomega"
 
@@ -178,11 +179,13 @@ func Test_000030_plan_only_no_outputs_test(t *testing.T) {
 			return nil
 		}
 		return map[string]interface{}{
-			"SavedPlan":   tfplanSecret.Labels["savedPlan"],
-			"TFPlanEmpty": string(tfplanSecret.Data["tfplan"]) == "",
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"TFPlanEmpty":           string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":   "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
-		"TFPlanEmpty": false,
+		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"TFPlanEmpty":           false,
+		"HasEncodingAnnotation": true,
 	}))
 }

--- a/controllers/tc000050_plan_and_manual_approve_no_outputs_test.go
+++ b/controllers/tc000050_plan_and_manual_approve_no_outputs_test.go
@@ -1,14 +1,15 @@
 package controllers
 
 import (
+	"os"
+	"testing"
+
 	infrav1 "github.com/chanwit/tf-controller/api/v1alpha1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"os"
-	"testing"
 
 	"context"
 	"time"
@@ -182,12 +183,14 @@ func Test_000050_plan_and_manual_approve_no_outputs_test(t *testing.T) {
 			return nil
 		}
 		return map[string]interface{}{
-			"SavedPlan":   tfplanSecret.Labels["savedPlan"],
-			"TFPlanEmpty": string(tfplanSecret.Data["tfplan"]) == "",
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"TFPlanEmpty":           string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":   planId,
-		"TFPlanEmpty": false,
+		"SavedPlan":             planId,
+		"TFPlanEmpty":           false,
+		"HasEncodingAnnotation": true,
 	}))
 
 	By("setting the .spec.approvePlan to be plan-main- and a part of commit id (b8e362c206) to approve the plan.")

--- a/controllers/tc000100_applied_should_tx_to_plan_when_source_changed_test.go
+++ b/controllers/tc000100_applied_should_tx_to_plan_when_source_changed_test.go
@@ -140,12 +140,14 @@ func Test_000100_applied_resource_should_transit_back_to_plan_when_source_change
 			return nil
 		}
 		return map[string]interface{}{
-			"SavedPlan":   tfplanSecret.Labels["savedPlan"],
-			"TFPlanEmpty": string(tfplanSecret.Data["tfplan"]) == "",
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"TFPlanEmpty":           string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":   "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
-		"TFPlanEmpty": false,
+		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"TFPlanEmpty":           false,
+		"HasEncodingAnnotation": true,
 	}))
 
 	By("manually approving the plan.")

--- a/controllers/tc000110_auto_applied_should_tx_to_plan_then_apply_when_source_changed_test.go
+++ b/controllers/tc000110_auto_applied_should_tx_to_plan_then_apply_when_source_changed_test.go
@@ -140,12 +140,14 @@ func Test_000110_auto_applied_resource_should_transit_to_plan_then_apply_when_so
 			return nil
 		}
 		return map[string]interface{}{
-			"SavedPlan":   tfplanSecret.Labels["savedPlan"],
-			"TFPlanEmpty": string(tfplanSecret.Data["tfplan"]) == "",
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"TFPlanEmpty":           string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":   "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
-		"TFPlanEmpty": false,
+		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"TFPlanEmpty":           false,
+		"HasEncodingAnnotation": true,
 	}))
 
 	By("manually approving the plan with auto.")

--- a/controllers/tc000130_destroy_no_outputs_test.go
+++ b/controllers/tc000130_destroy_no_outputs_test.go
@@ -2,10 +2,11 @@ package controllers
 
 import (
 	"context"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"os"
 	"testing"
 	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	. "github.com/onsi/gomega"
 
@@ -162,12 +163,14 @@ func Test_000130_destroy_no_outputs_test(t *testing.T) {
 			return nil
 		}
 		return map[string]interface{}{
-			"SavedPlan":         tfplanSecret.Labels["savedPlan"],
-			"Is TFPlan empty ?": string(tfplanSecret.Data["tfplan"]) == "",
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"Is TFPlan empty ?":     string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":         "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
-		"Is TFPlan empty ?": false,
+		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"Is TFPlan empty ?":     false,
+		"HasEncodingAnnotation": true,
 	}))
 
 	By("checking that the applied status of the TF program Successfully, and plan-master-b8e3 is applied")

--- a/controllers/tc000140_auto_applied_should_tx_to_plan_then_apply_when_drift_detected_test.go
+++ b/controllers/tc000140_auto_applied_should_tx_to_plan_then_apply_when_drift_detected_test.go
@@ -157,12 +157,14 @@ func Test_000140_auto_applied_resource_should_transit_to_plan_then_apply_when_dr
 			return nil
 		}
 		return map[string]interface{}{
-			"SavedPlan":         tfplanSecret.Labels["savedPlan"],
-			"Is TFPlan empty ?": string(tfplanSecret.Data["tfplan"]) == "",
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"Is TFPlan empty ?":     string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":         "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
-		"Is TFPlan empty ?": false,
+		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"Is TFPlan empty ?":     false,
+		"HasEncodingAnnotation": true,
 	}))
 
 	By("checking that the applied status of the TF program Successfully, and plan-master-b8e3 is applied")

--- a/controllers/tc000150_manual_apply_should_report_and_loop_when_drift_detected_test.go
+++ b/controllers/tc000150_manual_apply_should_report_and_loop_when_drift_detected_test.go
@@ -158,12 +158,14 @@ func Test_000150_manual_apply_should_report_and_loop_when_drift_detected_test(t 
 			return nil
 		}
 		return map[string]interface{}{
-			"SavedPlan":         tfplanSecret.Labels["savedPlan"],
-			"Is TFPlan empty ?": string(tfplanSecret.Data["tfplan"]) == "",
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"Is TFPlan empty ?":     string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":         "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
-		"Is TFPlan empty ?": false,
+		"SavedPlan":             "plan-master-b8e362c206e3d0cbb7ed22ced771a0056455a2fb",
+		"Is TFPlan empty ?":     false,
+		"HasEncodingAnnotation": true,
 	}))
 
 	createdHelloWorldTF.Spec.ApprovePlan = "plan-master-b8e362c206"

--- a/controllers/tc000160_auto_applied_should_tx_to_plan_when_unrelated_source_changed_test.go
+++ b/controllers/tc000160_auto_applied_should_tx_to_plan_when_unrelated_source_changed_test.go
@@ -203,12 +203,14 @@ func Test_000160_auto_applied_should_tx_to_plan_when_unrelated_source_changed_te
 			return nil
 		}
 		return map[string]interface{}{
-			"SavedPlan":   tfplanSecret.Labels["savedPlan"],
-			"TFPlanEmpty": string(tfplanSecret.Data["tfplan"]) == "",
+			"SavedPlan":             tfplanSecret.Labels["savedPlan"],
+			"TFPlanEmpty":           string(tfplanSecret.Data["tfplan"]) == "",
+			"HasEncodingAnnotation": tfplanSecret.Annotations["encoding"] != "" && tfplanSecret.Annotations["encoding"] == "gzip",
 		}
 	}, timeout, interval).Should(Equal(map[string]interface{}{
-		"SavedPlan":   "plan-master-ed22ced771a0056455a2fbb8e362c206e3d0cbb7",
-		"TFPlanEmpty": false,
+		"SavedPlan":             "plan-master-ed22ced771a0056455a2fbb8e362c206e3d0cbb7",
+		"TFPlanEmpty":           false,
+		"HasEncodingAnnotation": true,
 	}))
 
 	By("checking that the status of the TF resource must be transitioned to planned, no change.")

--- a/controllers/tc000210_plan_encode_decode_test.go
+++ b/controllers/tc000210_plan_encode_decode_test.go
@@ -1,0 +1,57 @@
+package controllers
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// +kubebuilder:docs-gen:collapse=Imports
+
+func Test_000210_plan_encode_decode_test(t *testing.T) {
+	Spec("This spec verifies gzip encoding and decoding func")
+
+	g := NewWithT(t)
+
+	encodeTests := []struct {
+		tfplan []byte
+	}{
+		{
+			tfplan: []byte("content"),
+		},
+	}
+
+	for _, tt := range encodeTests {
+		It("should encode the terraform plan")
+		r, err := reconciler.gzipEncode(tt.tfplan)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		var buf bytes.Buffer
+		w := gzip.NewWriter(&buf)
+		_, _ = w.Write(tt.tfplan)
+		w.Close()
+		g.Expect(r).Should(Equal(buf.Bytes()))
+	}
+
+	decodeTests := []struct {
+		encodedPlan []byte
+	}{
+		{
+			encodedPlan: []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xffJ\xce\xcf+I\xcd+\x01\x04\x00\x00\xff\xff\xa90\xc5\xfe\a\x00\x00\x00"),
+		},
+	}
+
+	for _, tt := range decodeTests {
+		It("should decode the encoded terraform plan")
+		r, err := reconciler.gzipDecode(tt.encodedPlan)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		re := bytes.NewReader(tt.encodedPlan)
+		gr, _ := gzip.NewReader(re)
+		o, _ := ioutil.ReadAll(gr)
+		g.Expect(r).Should(Equal(o))
+	}
+}

--- a/controllers/terraform_controller.go
+++ b/controllers/terraform_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -622,6 +623,16 @@ func (r *TerraformReconciler) plan(ctx context.Context, terraform infrav1.Terraf
 	planRev := strings.Replace(revision, "/", "-", 1)
 	planName := "plan-" + planRev
 
+	tfplan, err = r.gzipEncode(tfplan)
+	if err != nil {
+		return infrav1.TerraformNotReady(
+			terraform,
+			revision,
+			infrav1.TFExecPlanFailedReason,
+			err.Error(),
+		), err
+	}
+
 	tfplanData := map[string][]byte{"tfplan": tfplan}
 	tfplanSecret = corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -633,6 +644,9 @@ func (r *TerraformReconciler) plan(ctx context.Context, terraform infrav1.Terraf
 			Namespace: terraform.GetNamespace(),
 			Labels: map[string]string{
 				"savedPlan": planName,
+			},
+			Annotations: map[string]string{
+				"encoding": "gzip",
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -799,6 +813,17 @@ func (r *TerraformReconciler) apply(ctx context.Context, terraform infrav1.Terra
 	}
 
 	tfplan := tfplanSecret.Data[TFPlanName]
+
+	tfplan, err = r.gzipDecode(tfplan)
+	if err != nil {
+		return infrav1.TerraformNotReady(
+			terraform,
+			revision,
+			infrav1.TFExecApplyFailedReason,
+			err.Error(),
+		), err
+	}
+
 	err = ioutil.WriteFile(filepath.Join(tf.WorkingDir(), TFPlanName), tfplan, 0644)
 	if err != nil {
 		err = fmt.Errorf("error saving plan file to disk: %s", err)
@@ -1301,4 +1326,37 @@ func (r *TerraformReconciler) finalize(ctx context.Context, terraform infrav1.Te
 
 	// Stop reconciliation as the object is being deleted
 	return ctrl.Result{}, nil
+}
+
+func (r *TerraformReconciler) gzipEncode(tfplan []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+
+	_, err := w.Write(tfplan)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (r *TerraformReconciler) gzipDecode(encodedPlan []byte) ([]byte, error) {
+	re := bytes.NewReader(encodedPlan)
+	gr, err := gzip.NewReader(re)
+	if err != nil {
+		return nil, err
+	}
+
+	o, err := ioutil.ReadAll(gr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = gr.Close(); err != nil {
+		return nil, err
+	}
+	return o, nil
 }


### PR DESCRIPTION
Recreated PR for https://github.com/chanwit/tf-controller/pull/27 to fix bad rebase commit history.

This change introduces the ability to gzip encode larger than 1 MB plans so that they can still store as a secret.

Example usage:
```
apiVersion: infra.contrib.fluxcd.io/v1alpha1
kind: Terraform
metadata:
  name: helloworld
  namespace: flux-system
spec:
  approvePlan: "auto"
  path: ./
  sourceRef:
    kind: GitRepository
    name: helloworld
    namespace: flux-system
```
I tested it locally as well and seem to be working as expected.

Related issue: https://github.com/chanwit/tf-controller/issues/12