### PR TITLE
Test Suite Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ download-crd-deps:
 
 .PHONY: test
 test: manifests generate download-crd-deps fmt vet envtest ## Run tests.
-	DISABLE_TF_K8S_BACKEND=1 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	DISABLE_K8S_LOGS=1 DISABLE_TF_LOGS=1 DISABLE_TF_K8S_BACKEND=1 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./controllers -coverprofile cover.out -v
 
 ##@ Build
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -49,7 +49,9 @@ func init() {
 }
 
 const (
-	timeout  = time.Second * 10
+	// longer timeout duration is helpful to avoid flakiness when
+	// asserting on k8s resources created via Terraform
+	timeout  = time.Second * 30
 	interval = time.Millisecond * 500
 )
 

--- a/controllers/tc000140_auto_applied_should_tx_to_plan_then_apply_when_drift_detected_test.go
+++ b/controllers/tc000140_auto_applied_should_tx_to_plan_then_apply_when_drift_detected_test.go
@@ -287,5 +287,5 @@ func Test_000140_auto_applied_resource_should_transit_to_plan_then_apply_when_dr
 			return ""
 		}
 		return cmPayload.Name
-	}, timeout*3, interval).Should(Equal("cm-" + terraformName))
+	}, timeout, interval).Should(Equal("cm-" + terraformName))
 }

--- a/controllers/tc000160_auto_applied_should_tx_to_plan_when_unrelated_source_changed_test.go
+++ b/controllers/tc000160_auto_applied_should_tx_to_plan_when_unrelated_source_changed_test.go
@@ -134,7 +134,7 @@ func Test_000160_auto_applied_should_tx_to_plan_when_unrelated_source_changed_te
 			return -1
 		}
 		return len(createdHelloWorldTF.Status.Conditions)
-	}, timeout*3, interval).ShouldNot(BeZero())
+	}, timeout, interval).ShouldNot(BeZero())
 
 	By("checking that the applied status of the TF program Successfully, and plan-master-b8e362c206e is applied")
 	g.Eventually(func() map[string]interface{} {

--- a/controllers/tc000170_if_apply_error_we_should_delete_the_plan_and_start_over_test.go
+++ b/controllers/tc000170_if_apply_error_we_should_delete_the_plan_and_start_over_test.go
@@ -133,7 +133,7 @@ func Test_000170_if_apply_error_the_plan_should_be_deleted_and_start_over_test(t
 			return -1
 		}
 		return len(createdHelloWorldTF.Status.Conditions)
-	}, timeout*3, interval).ShouldNot(BeZero())
+	}, timeout, interval).ShouldNot(BeZero())
 
 	By("checking that the Ready status of the TF resource should fail, being TFExecApplyFailed.")
 	g.Eventually(func() map[string]interface{} {
@@ -173,7 +173,7 @@ func Test_000170_if_apply_error_the_plan_should_be_deleted_and_start_over_test(t
 			}
 		}
 		return nil
-	}, timeout*3, interval).Should(Equal(map[string]interface{}{
+	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":   "Apply",
 		"Reason": "TerraformAppliedSucceed",
 	}))

--- a/controllers/tc000201_auto_approve_with_disabled_drift_detection_test.go
+++ b/controllers/tc000201_auto_approve_with_disabled_drift_detection_test.go
@@ -18,9 +18,8 @@ func Test_000201_auto_approve_with_disabled_drift_detection(t *testing.T) {
 	Spec("This spec describes behaviour when drift detection is disabled")
 
 	const (
-		sourceName     = "drift-detect-auto-approve"
-		terraformName  = "tf-drift-detect-auto-approve"
-		tfSyncInterval = time.Second * 10
+		sourceName    = "drift-detect-auto-approve"
+		terraformName = "tf-drift-detect-auto-approve"
 	)
 
 	g := NewWithT(t)
@@ -83,7 +82,7 @@ func Test_000201_auto_approve_with_disabled_drift_detection(t *testing.T) {
 			Namespace: "flux-system",
 		},
 		Spec: infrav1.TerraformSpec{
-			Interval:              metav1.Duration{Duration: tfSyncInterval},
+			Interval:              metav1.Duration{Duration: time.Second * 5},
 			ApprovePlan:           "auto",
 			DisableDriftDetection: true,
 			Path:                  "./terraform-hello-world-example",
@@ -157,5 +156,5 @@ func Test_000201_auto_approve_with_disabled_drift_detection(t *testing.T) {
 			}
 		}
 		return false
-	}, tfSyncInterval*2, interval).Should(BeTrue())
+	}, timeout, interval).Should(BeTrue())
 }

--- a/controllers/tc000220_support_config_file_via_secret_test.go
+++ b/controllers/tc000220_support_config_file_via_secret_test.go
@@ -149,7 +149,7 @@ credentials "app.terraform.io" {
 			}
 		}
 		return helloWorldTF.Status
-	}, timeout*6, interval).Should(Equal(map[string]interface{}{
+	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":    "Plan",
 		"Reason":  "TerraformPlannedWithChanges",
 		"Message": "Plan generated",
@@ -191,7 +191,7 @@ credentials "app.terraform.io" {
 			}
 		}
 		return nil
-	}, timeout*6, interval).Should(Equal(map[string]interface{}{
+	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":            "Apply",
 		"Reason":          "TerraformAppliedSucceed",
 		"Message":         "Applied successfully",
@@ -219,7 +219,7 @@ credentials "app.terraform.io" {
 			}
 		}
 		return nil
-	}, timeout*12, interval).Should(Equal(map[string]interface{}{
+	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":            "Apply",
 		"Reason":          "TerraformAppliedSucceed",
 		"Message":         "Applied successfully",

--- a/controllers/tc000230_drift_detection_only_mode_test.go
+++ b/controllers/tc000230_drift_detection_only_mode_test.go
@@ -171,7 +171,7 @@ func Test_000230_drift_detection_only_mode(t *testing.T) {
 			}
 		}
 		return createdTFResource.Status
-	}, timeout*2, interval).Should(Equal(map[string]interface{}{
+	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":   "Ready",
 		"Status": metav1.ConditionTrue,
 		"Reason": infrav1.NoDriftReason,
@@ -198,7 +198,7 @@ func Test_000230_drift_detection_only_mode(t *testing.T) {
 			}
 		}
 		return createdTFResource.Status
-	}, timeout*2, interval).Should(Equal(map[string]interface{}{
+	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":   "Ready",
 		"Status": metav1.ConditionTrue,
 		"Reason": infrav1.NoDriftReason,
@@ -234,7 +234,7 @@ func Test_000230_drift_detection_only_mode(t *testing.T) {
 			}
 		}
 		return createdTFResource.Status
-	}, timeout*2, interval).Should(Equal(map[string]interface{}{
+	}, timeout, interval).Should(Equal(map[string]interface{}{
 		"Type":   "Ready",
 		"Status": metav1.ConditionFalse,
 		"Reason": infrav1.DriftDetectedReason,

--- a/controllers/terraform_controller.go
+++ b/controllers/terraform_controller.go
@@ -507,9 +507,12 @@ terraform {
 		}
 	}
 
-	tf.SetStdout(os.Stdout)
-	tf.SetStderr(os.Stderr)
-	tf.SetLogger(&LocalPrintfer{logger: log})
+	disableTestLogging := os.Getenv("DISABLE_TF_LOGS") == "1"
+	if !disableTestLogging {
+		tf.SetStdout(os.Stdout)
+		tf.SetStderr(os.Stderr)
+		tf.SetLogger(&LocalPrintfer{logger: log})
+	}
 
 	log.Info("new terraform", "workingDir", workingDir)
 


### PR DESCRIPTION
This PR introduces the following changes in order to prepare the ground for test suite automation (#35) .

Items addressed are as follows:
- Increase global timeout to 30s to mitigate flaky asynchronous tests involving Terraform plan & apply operations
- Add environment variables to allow disabling Kubernetes and Terraform logs for more readable test output
- Update Makefile to use `go test -v ./controllers` so that test result output is streamed as the individual tests run (rather than at the end of the entire run).