### PR TITLE
Add Drift Detection Status Fields 

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -227,6 +227,8 @@ func (in *TerraformStatus) DeepCopyInto(out *TerraformStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	in.LastDriftDetectedAt.DeepCopyInto(&out.LastDriftDetectedAt)
+	in.LastAppliedByDriftDetectionAt.DeepCopyInto(&out.LastAppliedByDriftDetectionAt)
 	if in.AvailableOutputs != nil {
 		in, out := &in.AvailableOutputs, &out.AvailableOutputs
 		*out = make([]string, len(*in))

--- a/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
+++ b/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
@@ -412,6 +412,10 @@ spec:
                   - type
                   type: object
                 type: array
+              lastAppliedByDriftDetectionAt:
+                description: LastAppliedByDriftDetectionAt
+                format: date-time
+                type: string
               lastAppliedRevision:
                 description: The last successfully applied revision. The revision
                   format for Git sources is <branch|tag>/<commit-sha>.
@@ -419,6 +423,10 @@ spec:
               lastAttemptedRevision:
                 description: LastAttemptedRevision is the revision of the last reconciliation
                   attempt.
+                type: string
+              lastDriftDetectedAt:
+                description: LastDriftDetectedAt
+                format: date-time
                 type: string
               lastHandledReconcileAt:
                 description: LastHandledReconcileAt holds the value of the most recent
@@ -436,6 +444,8 @@ spec:
               plan:
                 properties:
                   isDestroyPlan:
+                    type: boolean
+                  isDriftDetectionPlan:
                     type: boolean
                   lastApplied:
                     type: string

--- a/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
+++ b/config/crd/bases/infra.contrib.fluxcd.io_terraforms.yaml
@@ -413,7 +413,8 @@ spec:
                   type: object
                 type: array
               lastAppliedByDriftDetectionAt:
-                description: LastAppliedByDriftDetectionAt
+                description: LastAppliedByDriftDetectionAt is the time when the last
+                  drift was detected and terraform apply was performed as a result
                 format: date-time
                 type: string
               lastAppliedRevision:
@@ -425,7 +426,8 @@ spec:
                   attempt.
                 type: string
               lastDriftDetectedAt:
-                description: LastDriftDetectedAt
+                description: LastDriftDetectedAt is the time when the last drift was
+                  detected
                 format: date-time
                 type: string
               lastHandledReconcileAt:

--- a/controllers/tc000150_manual_apply_should_report_and_loop_when_drift_detected_test.go
+++ b/controllers/tc000150_manual_apply_should_report_and_loop_when_drift_detected_test.go
@@ -239,6 +239,15 @@ func Test_000150_manual_apply_should_report_and_loop_when_drift_detected_test(t 
 	By("deleting configmap to create a drift")
 	g.Expect(k8sClient.Delete(ctx, &cmPayload)).Should(Succeed())
 
+	By("checking that the drift got detected, setting LastDriftDetectedAt time")
+	g.Eventually(func() bool {
+		err := k8sClient.Get(ctx, helloWorldTFKey, &createdHelloWorldTF)
+		if err != nil {
+			return false
+		}
+		return !createdHelloWorldTF.Status.LastDriftDetectedAt.IsZero()
+	}, timeout, interval).Should(BeTrue())
+
 	By("checking that the drift got detected, applying is progressing")
 	g.Eventually(func() map[string]string {
 		err := k8sClient.Get(ctx, helloWorldTFKey, &createdHelloWorldTF)

--- a/controllers/tc000230_drift_detection_only_mode_test.go
+++ b/controllers/tc000230_drift_detection_only_mode_test.go
@@ -206,6 +206,14 @@ func Test_000230_drift_detection_only_mode(t *testing.T) {
 		"Reason": infrav1.NoDriftReason,
 	}))
 
+	g.Eventually(func() bool {
+		err := k8sClient.Get(ctx, testTFKey, &createdTFResource)
+		if err != nil {
+			return false
+		}
+		return createdTFResource.Status.LastDriftDetectedAt.IsZero()
+	}, timeout, interval).Should(BeTrue())
+
 	It("should continue to detect and report drift")
 	By("deleting configmap to create a drift")
 	cmPayloadKey := types.NamespacedName{Namespace: "default", Name: "cm-" + terraformName}
@@ -242,4 +250,11 @@ func Test_000230_drift_detection_only_mode(t *testing.T) {
 		"Reason": infrav1.DriftDetectedReason,
 	}))
 
+	g.Eventually(func() bool {
+		err := k8sClient.Get(ctx, testTFKey, &createdTFResource)
+		if err != nil {
+			return false
+		}
+		return !createdTFResource.Status.LastDriftDetectedAt.IsZero()
+	}, timeout, interval).Should(BeTrue())
 }

--- a/controllers/terraform_controller.go
+++ b/controllers/terraform_controller.go
@@ -339,7 +339,6 @@ func (l LocalPrintfer) Printf(format string, v ...interface{}) {
 }
 
 func (r *TerraformReconciler) reconcile(ctx context.Context, terraform infrav1.Terraform, sourceObj sourcev1.Source) (infrav1.Terraform, error) {
-
 	log := ctrl.LoggerFrom(ctx)
 	revision := sourceObj.GetArtifact().Revision
 	objectKey := types.NamespacedName{Namespace: terraform.Namespace, Name: terraform.Name}
@@ -576,7 +575,8 @@ terraform {
 	log.Info("generated var files from spec")
 
 	if r.shouldDetectDrift(terraform, revision) {
-		terraform, driftDetectionErr := r.detectDrift(ctx, terraform, tf, revision)
+		var driftDetectionErr error // declared here to avoid shadowing on terraform variable
+		terraform, driftDetectionErr = r.detectDrift(ctx, terraform, tf, revision)
 
 		// immediately return if no drift - reconciliation will retry normally
 		if driftDetectionErr == nil {

--- a/docs/api/terraform.md
+++ b/docs/api/terraform.md
@@ -292,6 +292,17 @@ bool
 <em>(Optional)</em>
 </td>
 </tr>
+<tr>
+<td>
+<code>isDriftDetectionPlan</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -875,6 +886,35 @@ string
 <em>(Optional)</em>
 <p>LastPlannedRevision is the revision used by the last planning process.
 The result could be either no plan change or a new plan generated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastDriftDetectedAt</code><br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LastDriftDetectedAt is the time when the last drift was detected</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastAppliedByDriftDetectionAt</code><br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LastAppliedByDriftDetectionAt is the time when the last drift was detected and
+terraform apply was performed as a result</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
This PR adds the following status fields to the Terraform resource:
-  `LastDriftDetectedAt`
-  `LastAppliedByDriftDetectionAt`

Also includes a fix for a sneaky variable shadowing problem in the drift detection code.

Fixes #7 
